### PR TITLE
fix(yaml): clean trailing spaces and fix comment formatting

### DIFF
--- a/playbooks/example.pl_install_docker.yml
+++ b/playbooks/example.pl_install_docker.yml
@@ -29,9 +29,6 @@
         max-size: "100m"
         max-file: "3"
 
-    # Optional: pin to nightly channel (advanced)
-    # docker_apt_release_channel: nightly
-
   tasks:
     - name: Include install_docker role
       ansible.builtin.include_role:

--- a/playbooks/example.pl_zbx_proxy_agent.yml
+++ b/playbooks/example.pl_zbx_proxy_agent.yml
@@ -15,32 +15,32 @@
 
     ## AGENT settings
     # Agent connects to the local proxy service
-      # Note: zbx_agent_server_host controls where the Zabbix Agent sends its active connections.
-      # - For server_agent: set to the Server service (typically 'zabbix-server')
-      # - For proxy_agent: set to the Proxy service (typically 'zabbix-proxy')
-      # - For agent-only: set to a reachable address (IP/FQDN) of your Server or Proxy
-      # In this Proxy+Agent playbook, the agent should use the local proxy.
+    # Note: zbx_agent_server_host controls where the Zabbix Agent sends its active connections.
+    # - For server_agent: set to the Server service (typically 'zabbix-server')
+    # - For proxy_agent: set to the Proxy service (typically 'zabbix-proxy')
+    # - For agent-only: set to a reachable address (IP/FQDN) of your Server or Proxy
+    # In this Proxy+Agent playbook, the agent should use the local proxy.
     # If both agent and proxy use host networking, point agent to local host
     # hostname; otherwise use the proxy's compose service/hostname.
     zbx_agent_server_host: "{{ (zabbix_agent_network_mode_host and zabbix_proxy_network_mode_host) | ternary(ansible_hostname, zbx_proxy_hostname) }}"
     # Agent hostname as shown in Zabbix
-      # Note: zbx_agent_hostname is the host name as it will appear in Zabbix.
-      # Use a stable, unique identifier (e.g., OS hostname or FQDN).
-      # This value is also used to derive the default PSK identity
-      # ("<hostname>-identity") for secure agent-server/proxy communication.
+    # Note: zbx_agent_hostname is the host name as it will appear in Zabbix.
+    # Use a stable, unique identifier (e.g., OS hostname or FQDN).
+    # This value is also used to derive the default PSK identity
+    # ("<hostname>-identity") for secure agent-server/proxy communication.
     zbx_agent_hostname: "agent-local"
 
     ## PROXY settings
     # Proxy sends data to the server; use compose service or external IP/FQDN
-      # Note: zbx_proxy_server_host is where the proxy sends data (the Zabbix Server).
-      # Use the server service name within Compose (typically 'zabbix-server')
-      # or an IP/FQDN if the server is external.
+    # Note: zbx_proxy_server_host is where the proxy sends data (the Zabbix Server).
+    # Use the server service name within Compose (typically 'zabbix-server')
+    # or an IP/FQDN if the server is external.
     zbx_proxy_server_host: "zabbix-server"
 
     # Proxy identity shown in Zabbix (also used for PSK identity defaults)
-      # Note: zbx_proxy_hostname is the proxy's identity shown in Zabbix and
-      # used for PSK identity defaults ("<proxy-hostname>-identity").
-      # Choose a stable, unique name for your environment.
+    # Note: zbx_proxy_hostname is the proxy's identity shown in Zabbix and
+    # used for PSK identity defaults ("<proxy-hostname>-identity").
+    # Choose a stable, unique name for your environment.
     zbx_proxy_hostname: "zbx-proxy-local"
 
     # Optional: API registration (adjust to your server/proxy names and credentials)

--- a/playbooks/pl_zbx_docker_setup_proxy_agent_local.yml
+++ b/playbooks/pl_zbx_docker_setup_proxy_agent_local.yml
@@ -13,24 +13,24 @@
     zabbix_version: '7.4.5'
     zabbix_image_flavor: "alpine"
 
-    #! Zabbix deployment mode: 
+    # Zabbix deployment mode:
     zabbix_deployment_mode: 'proxy_agent'
 
-    #! for .env_agent
+    # for .env_agent
     # Agent connects to the Proxy service
-    zbx_agent_server_host: 'zabbix-proxy' 
+    zbx_agent_server_host: 'zabbix-proxy'
 
     # Agent hostname as shown in Zabbix
-    zbx_agent_hostname: 'agent-hostname' #! change to your agent hostname
+    zbx_agent_hostname: 'agent-hostname'  # change to your agent hostname
 
-    #! for API
+    # for API
     zabbix_api_proxy: "z-proxy-Test" # Name of proxy in Zabbix server
     zabbix_host_groups:
       - "Zabbix-Proxy"
     zabbix_link_templates:
       - "Linux by Zabbix agent"
 
-    #! for .env_prx
+    # for .env_prx
     # Proxy sends data to the server; use compose service or external IP/FQDN
     zbx_proxy_server_host: 'zabbix-server'
 
@@ -38,7 +38,7 @@
     zbx_proxy_hostname: 'zbx-proxy-hostname'
 
   tasks:
-      # Install Docker on non-Windows control machines only
+    # Install Docker on non-Windows control machines only
     - name: Role install docker
       ansible.builtin.include_role:
         name: install_docker

--- a/roles/install_zabbix_docker/tasks/main.yml
+++ b/roles/install_zabbix_docker/tasks/main.yml
@@ -34,7 +34,7 @@
 
 - name: Create Zabbix host via API
   ansible.builtin.include_tasks: api.yml
-  when: 
+  when:
     - check_container is defined
     - (check_container.failed | default(false)) == false
     - (zabbix_api_create_hosts | bool) or (zabbix_api_create_proxy | bool) or (zabbix_api_create_hostgroup | bool)

--- a/roles/install_zabbix_docker/vars/zabbix_agent_conf.yml
+++ b/roles/install_zabbix_docker/vars/zabbix_agent_conf.yml
@@ -20,7 +20,7 @@ zabbix_agent_timeout: 20
 # Userparams
 zabbix_agent_userparams: False
 ####### user-defined monitored parameters #######
-#zabbix_agent_unsafeuserparameters: 1
+# zabbix_agent_unsafeuserparameters: 1
 
 ####### TLS-RELATED PARAMETERS #######
 # Option: TLSConnect


### PR DESCRIPTION
## Summary

Remove trailing spaces, fix comment formatting (missing starting space), and align comment indentation across YAML files.

## Changes
- `playbooks/pl_zbx_docker_setup_proxy_agent_local.yml`: fix `#!` → `#` comments, remove trailing spaces, align comment indent
- `roles/install_zabbix_docker/tasks/main.yml`: remove trailing space after `when:`
- `roles/install_zabbix_docker/vars/zabbix_agent_conf.yml`: add space after `#` in commented var
- `playbooks/example.pl_zbx_proxy_agent.yml`: reduce Note block indent from 6 to 4 spaces
- `playbooks/example.pl_install_docker.yml`: remove orphaned commented-out config

Closes #7