### PR TITLE
fix(yaml): add document-start markers, fix truthy values and indentation

### DIFF
--- a/roles/install_docker/.travis.yml
+++ b/roles/install_docker/.travis.yml
@@ -9,7 +9,7 @@ sudo: false
 addons:
   apt:
     packages:
-    - python-pip
+      - python-pip
 
 install:
   # Install ansible

--- a/roles/install_zabbix_docker/.travis.yml
+++ b/roles/install_zabbix_docker/.travis.yml
@@ -9,7 +9,7 @@ sudo: false
 addons:
   apt:
     packages:
-    - python-pip
+      - python-pip
 
 install:
   # Install ansible

--- a/roles/install_zabbix_docker/meta/main.yml
+++ b/roles/install_zabbix_docker/meta/main.yml
@@ -1,3 +1,4 @@
+---
 galaxy_info:
   author: DenAV
   description: Deploy Zabbix monitoring stack via Docker Compose
@@ -21,5 +22,3 @@ galaxy_info:
     - compose
 
 dependencies: []
-  # List your role dependencies here, one per line. Be sure to remove the '[]' above,
-  # if you add dependencies to this list.

--- a/roles/install_zabbix_docker/vars/zabbix_agent_conf.yml
+++ b/roles/install_zabbix_docker/vars/zabbix_agent_conf.yml
@@ -1,3 +1,4 @@
+---
 # Variables for zabbix_agent.conf on Windows OS
 #
 # Option: logfile
@@ -18,7 +19,7 @@ zabbix_agent_maxlinespersecond: 20
 # Option: Timeout
 zabbix_agent_timeout: 20
 # Userparams
-zabbix_agent_userparams: False
+zabbix_agent_userparams: false
 ####### user-defined monitored parameters #######
 #zabbix_agent_unsafeuserparameters: 1
 


### PR DESCRIPTION
## Summary

Add missing YAML document start markers, fix truthy values, and correct list indentation.

## Changes
- `roles/install_zabbix_docker/meta/main.yml`: add `---` document start, remove scaffold comments
- `roles/install_zabbix_docker/vars/zabbix_agent_conf.yml`: add `---`, fix `False` → `false`
- `roles/install_docker/.travis.yml`: fix list indentation under `packages:`
- `roles/install_zabbix_docker/.travis.yml`: fix list indentation under `packages:`

Closes #9