### PR TITLE
fix(markdown): convert setext headings to ATX style in role READMEs

### DIFF
--- a/roles/install_docker/README.md
+++ b/roles/install_docker/README.md
@@ -1,10 +1,8 @@
-Install Docker Role
-===================
+# Install Docker Role
 
 This role installs and configures Docker Engine on Debian/Ubuntu hosts, sets up the official Docker APT repository, installs Docker packages, and optionally configures daemon options and adds users to the `docker` group. It also ensures the Docker service is enabled and running.
 
-Requirements
-------------
+## Requirements
 
 - Ansible >= 2.10
 - Target OS: Debian 11/12 or Ubuntu 20.04/22.04 (systemd-based)
@@ -12,8 +10,7 @@ Requirements
 - Become (sudo) privileges for package installation and service management
 - Internet access to reach Docker APT repositories
 
-Role Variables
---------------
+## Role Variables
 
 Defined in `defaults/main.yml`:
 
@@ -33,8 +30,7 @@ Defined in `defaults/main.yml`:
 - `docker_compose_plugin_install` (bool, default: `true`): Whether to install the Compose v2 plugin.
 - `zabbix_gid` (int, default: `1995`), `zabbix_uid` (int, default: `1997`): IDs used for the `zabbix` group/user.
 
-Behavior Overview
------------------
+## Behavior Overview
 
 - Removes any legacy Docker packages (`docker`, `docker-engine`, `docker.io`, `containerd`, `runc`).
 - Installs apt prerequisites (`apt-transport-https`, `ca-certificates`, `lsb-release`, `curl`, `gnupg`).
@@ -47,18 +43,15 @@ Behavior Overview
 - Creates a `zabbix` group (gid 1995) and user (uid 1997, shell `/sbin/nologin`) used by the broader project.
   - These IDs are configurable via `zabbix_gid` and `zabbix_uid`.
 
-Handlers
---------
+## Handlers
 
 - `restart docker`: Restarts the Docker service using `docker_restart_handler_state` when configuration or package changes occur.
 
-Dependencies
-------------
+## Dependencies
 
 None.
 
-Example Playbooks
------------------
+## Example Playbooks
 
 Install Docker with default settings and add an extra user to the `docker` group:
 
@@ -100,8 +93,7 @@ Pin to the nightly APT channel (advanced):
         docker_apt_release_channel: nightly
 ```
 
-Notes
------
+## Notes
 
 - This role currently targets Debian-family distributions; the `install_docker.yml` tasks run only when `ansible_os_family == 'Debian'`.
 - Compose v2 is provided by `docker-compose-plugin`; use `docker compose ...` instead of `docker-compose`.
@@ -113,12 +105,10 @@ Notes
 
 Tip: Ansible tasks using this role typically run with `become: true`, so Docker operations succeed even before your interactive shell has refreshed group membership.
 
-License
--------
+## License
 
 BSD
 
-Author Information
-------------------
+## Author Information
 
 Maintained by the `ansible-zabbix-docker` project. For issues and contributions, please use the repository's issue tracker.

--- a/roles/install_zabbix_docker/README.md
+++ b/roles/install_zabbix_docker/README.md
@@ -1,10 +1,8 @@
-Install Zabbix (Docker) Role
-============================
+# Install Zabbix (Docker) Role
 
 This role deploys Zabbix components (server, proxy, web, web-service, agent) using Docker Compose on Debian/Ubuntu hosts. It supports Zabbix 7.4.5, generates TLS PSK secrets, and can register/update hosts via the Zabbix API.
 
-Requirements
-------------
+## Requirements
 
 - Ansible >= 2.10
 - Docker Engine + Compose v2 (via `docker compose`)
@@ -12,8 +10,7 @@ Requirements
 - Become (sudo) privileges on the target machine
 - Internet access to pull Zabbix and DB images
 
-Role Variables
---------------
+## Role Variables
 
 Key variables (see `defaults/main.yml` for full list):
 
@@ -45,8 +42,7 @@ API & PSK:
 - `zabbix_agent_tlspsk_secret`, `zabbix_agent_tlspskidentity`: PSK secret and identity used by agent and API updates. By default `zabbix_agent_tlspskidentity` maps to `zbx_agent_psk_identity`.
 - `zabbix_api_proxy`: proxy name as it exists in the Zabbix server, used when registering hosts via API (defaults to `zbx_proxy_hostname`).
 
-Behavior Overview
------------------
+## Behavior Overview
 
 - Renders environment files for selected deployment mode and builds a Docker Compose file from templates.
 - Uses dynamic image tags like `zabbix/zabbix-server-mysql:{{ zabbix_image_tag }}`.
@@ -54,8 +50,7 @@ Behavior Overview
 - Starts services with `docker compose` via the Ansible Docker collection.
 - Optionally registers/updates hosts in Zabbix using API calls once services are up.
 
-Security Hardening
-------------------
+## Security Hardening
 
 - Agent container runs without `privileged`, `pid: host`, or `network_mode: host` by default; enable only when necessary.
 - Configure capabilities via `zabbix_agent_cap_add` (e.g., `SYS_PTRACE`, `NET_RAW`) rather than full privilege.
@@ -63,8 +58,7 @@ Security Hardening
 - Consider moving Zabbix API credentials and PSK secrets to Ansible Vault.
 - Add resource limits and healthchecks for server/proxy if desired.
 
-Example Playbooks
------------------
+## Example Playbooks
 
 Server + Agent on Ubuntu 24.04 with Zabbix 7.4.5 (alpine):
 
@@ -95,25 +89,21 @@ Proxy + Agent with custom subnets:
         zbx_net_frontend_subnet: "10.20.38.0/24"
 ```
 
-Dependencies
-------------
+## Dependencies
 
 - `community.docker` Ansible collection for Compose tasks.
 - Docker Engine with Compose v2 on target host.
 
-Notes
------
+## Notes
 
 - Templates previously defaulted to 6.x images; now use `zabbix_version` and `zabbix_image_tag`. Ensure the tag exists in Docker Hub.
 - If using host networking for agent, review security implications carefully.
 - For MySQL tuning/SSL, enable related `ZBX_DBTLS*` variables in `.env_srv` and secrets.
 
-License
--------
+## License
 
 BSD
 
-Author Information
-------------------
+## Author Information
 
 Maintained by the `ansible-zabbix-docker` project. Contributions and issues via repository tracker.


### PR DESCRIPTION
## Summary

Convert all setext-style headings (underline `===` / `---`) to ATX style (`#` / `##`) in both role README files.

## Changes
- `roles/install_docker/README.md`: 10 headings converted
- `roles/install_zabbix_docker/README.md`: 10 headings converted

Closes #11