### PR TITLE
fix(markdown): add blank lines around headings, lists, and fences

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,15 +8,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ## [0.1.0] - 2025-12-26
+
 ### Added
+
 - Bootstrap documentation structure
 - LICENSE (BSD 3-Clause)
 - Verified presence of PR template
 
 ### Changed
+
 - README clarified quick start and pointers to role docs
 
 ### Security
+
 - No changes
 
 <!--

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 This project installs Zabbix locally using Docker containers via Ansible. It supports multiple deployment variants (server+agent, proxy+agent, proxy-only, agent-only) and targets Zabbix 7.4.5 on Ubuntu 24.04 LTS (and Debian 11/12).
 
 **Components**
+
 - Role `install_docker`: Installs Docker Engine and Compose v2 with best-practice apt keyring.
 - Role `install_zabbix_docker`: Generates env files, renders Compose, deploys Zabbix stack, manages TLS PSK, and optionally registers hosts via API.
 

--- a/TROUBLESHOOTING.md
+++ b/TROUBLESHOOTING.md
@@ -3,6 +3,7 @@
 Use this checklist to validate Docker/Compose setup, containers, networking, and Zabbix agent/proxy configuration.
 
 ## Quick Status
+
 - Compose config: `cd /zabbix && sudo docker compose config`
 - Services list: `sudo docker compose ps`
 - Logs (last 200):
@@ -11,16 +12,19 @@ Use this checklist to validate Docker/Compose setup, containers, networking, and
   - Server: `sudo docker logs zabbix-server --tail=200`
 
 ## Images & Recreate
+
 - Pull images: `sudo docker compose pull`
 - Up/refresh: `sudo docker compose up -d --pull=always`
 - Stop/remove: `sudo docker compose down`
 
 ## Health & Ports
+
 - Agent port: `timeout 1 bash -c '</dev/tcp/127.0.0.1/10050' && echo OK || echo FAIL`
 - Proxy port: `timeout 1 bash -c '</dev/tcp/127.0.0.1/10051' && echo OK || echo FAIL`
 - Server port: `timeout 1 bash -c '</dev/tcp/127.0.0.1/10051' && echo OK || echo WAIT`
 
 ## Networks
+
 - List networks: `sudo docker network ls`
 - Inspect frontend: `sudo docker network inspect zbx_net_frontend | jq '.[0].IPAM.Config'`
 - Container DNS reachability:
@@ -28,6 +32,7 @@ Use this checklist to validate Docker/Compose setup, containers, networking, and
   - `sudo docker exec zabbix-proxy getent hosts zabbix-server`
 
 ## Agent Configuration
+
 - Environment applied: `sudo docker exec zabbix-agent env | grep ZBX_`
 - PSK secret file: `sudo docker exec zabbix-agent cat /var/lib/zabbix/enc/secret.psk`
 - Identity (from env): check `cat /zabbix/env_vars/.env_agent` for `ZBX_TLSPSKIDENTITY`
@@ -36,6 +41,7 @@ Use this checklist to validate Docker/Compose setup, containers, networking, and
 - Print built-in items: `sudo docker exec zabbix-agent zabbix_agentd -p | head`
 
 ## Proxy Configuration
+
 - Environment applied: `sudo docker exec zabbix-proxy env | grep ZBX_`
 - PSK secret file: `sudo docker exec zabbix-proxy cat /var/lib/zabbix/enc/secret.psk`
 - Server target:
@@ -44,6 +50,7 @@ Use this checklist to validate Docker/Compose setup, containers, networking, and
   - Note: the image reads `ZBX_*` environment variables; the base `zabbix_proxy.conf` includes modular files and may not contain the server host directly.
 
 ## Common Errors & Fixes
+
 - YAML error ("mapping values are not allowed"):
   - Inspect `/zabbix/docker-compose.yml` and fix indentation/empty keys.
   - Validate: `sudo docker compose config`.
@@ -57,22 +64,26 @@ Use this checklist to validate Docker/Compose setup, containers, networking, and
   - Verify: `docker compose version`
 
 ## Zabbix API Readiness
+
 - Wait for server/proxy ports before API calls:
   - Server: `timeout 1 bash -c '</dev/tcp/127.0.0.1/10051' && echo Server OK || echo WAIT'`
   - Proxy: `timeout 1 bash -c '</dev/tcp/127.0.0.1/10051' && echo Proxy OK || echo WAIT'`
 - Check credentials/vault values (`zabbix_api_url`, `zabbix_api_user`, `zabbix_api_pass`).
 
 ## Regenerate PSK
+
 - Path on host: `/zabbix/zbx_env/var/enc/secret.psk`
 - Permissions: `sudo chmod 0640 /zabbix/zbx_env/var/enc/secret.psk`
 - Re-run playbook to auto-generate if missing.
 
 ## Compose File Locations
+
 - Compose project directory: `/zabbix`
 - Env files rendered: `/zabbix/env_vars/.env_*`
 - Local volumes base: `/zabbix/zbx_env/...`
 
 ## Collect Diagnostics
+
 - Compose details: `sudo docker compose config > /tmp/compose.out`
 - Container inspect:
   - `sudo docker inspect zabbix-agent > /tmp/agent.inspect.json`

--- a/roles/install_zabbix_docker/README.md
+++ b/roles/install_zabbix_docker/README.md
@@ -27,6 +27,7 @@ Key variables (see `defaults/main.yml` for full list):
 - `zbx_container_state`: desired compose state (`present` or `absent`).
 
 Security & networking:
+
 - `zabbix_agent_privileged`: default `false`; avoid privileged unless required.
 - `zabbix_agent_pid_host`: default `false`; disable host PID namespace by default.
 - `zabbix_agent_network_mode_host`: default `false`; avoid host networking by default.
@@ -39,6 +40,7 @@ Security & networking:
 - `zabbix_enable_healthchecks`: default `true`; adds simple healthchecks to agent and can be extended to other services.
 
 API & PSK:
+
 - `zabbix_install_pip_packages`: default `true` (installs `zabbix-api` on localhost).
 - `zbx_pskfile_secret`: generated automatically if missing; stored at `{{ zbx_volumes_local_path }}/var/enc/secret.psk`.
 - `zabbix_api_create_hostgroup`, `zabbix_api_create_hosts`: booleans controlling API automation.

--- a/utils/database/README.md
+++ b/utils/database/README.md
@@ -3,6 +3,7 @@
 This directory contains utility scripts for backing up and validating Zabbix database backups.
 
 ## How to use backup with password file
+
 ```bash
 chmod +x backup-zabbix-db-pwd.sh
 ./backup-zabbix-db-pwd.sh


### PR DESCRIPTION
## Summary

Add missing blank lines around headings, lists, and fenced code blocks per markdownlint MD022/MD031/MD032.

## Changes
- `CHANGELOG.md`: blank lines between consecutive headings and lists
- `TROUBLESHOOTING.md`: blank line after every `##` heading before list
- `README.md`: blank line after **Components** before list
- `utils/database/README.md`: blank line between heading and fenced block
- `roles/install_zabbix_docker/README.md`: blank lines before sub-section lists

Closes #13